### PR TITLE
If the `token` input is not provided, default to the `GITHUB_TOKEN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,5 @@ jobs:
     steps:
       - uses: JuliaRegistries/compathelper-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,15 +7,15 @@ branding:
   color: 'green'
 
 inputs:
-  ### Required inputs
-  token:
-    description: 'A GitHub token with write access on your repository'
-    required: true
   ### Optional inputs
   ssh:
     description: 'An SSH deploy key with write access on your repository'
     required: false
     default: ''
+  token:
+    description: 'A GitHub token with write access on your repository'
+    required: false
+    default: ${{ github.token }}
   version:
     description: 'Major version of CompatHelper.jl to use'
     required: false

--- a/example.yml
+++ b/example.yml
@@ -9,5 +9,4 @@ jobs:
     steps:
       - uses: JuliaRegistries/compathelper-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Fixes #5 