### PR TITLE
Make `token` a required input

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ jobs:
     steps:
       - uses: JuliaRegistries/compathelper-action@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ branding:
   color: 'green'
 
 inputs:
+  ### Required inputs
+  token:
+    description: 'A GitHub token with write access on your repository'
+    required: true
   ### Optional inputs
   cmd:
     description: 'The CompatHelper command to run. If you provide this input, you MUST also provide the `version` input.'
@@ -16,10 +20,6 @@ inputs:
     description: 'An SSH deploy key with write access on your repository'
     required: false
     default: ''
-  token:
-    description: 'A GitHub token with write access on your repository'
-    required: false
-    default: ${{ github.token }}
   version:
     description: 'Major version of CompatHelper.jl to use'
     required: false

--- a/example.yml
+++ b/example.yml
@@ -9,4 +9,5 @@ jobs:
     steps:
       - uses: JuliaRegistries/compathelper-action@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
While it is slick that we can get away with using the default token, I think it's better if we make it explicitly clear to the user that we are using the token. That way, users won't be surprised to learn that we are using their GitHub token.