### PR TITLE
Update description for `version` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ''
   version:
-    description: 'Major version of CompatHelper.jl to use'
+    description: 'Version of CompatHelper.jl to use'
     required: false
     default: '3'
 


### PR DESCRIPTION
The `inputs.version` is passed directly into `Pkg.add`, so it doesn't have to be a major version.